### PR TITLE
[2] Update common geo functions

### DIFF
--- a/nesta_daps/common/geo/geocode.py
+++ b/nesta_daps/common/geo/geocode.py
@@ -6,16 +6,16 @@ Tools for geocoding.
 """
 
 import logging
+import time
 from functools import cache
 
 import pandas as pd
-
-import ratelimit
 
 import requests
 
 from retrying import retry
 
+from nesta_daps.common.geo.ratelimit import ratelimit
 
 @cache
 def geocode(**request_kwargs):

--- a/nesta_daps/common/geo/geocode.py
+++ b/nesta_daps/common/geo/geocode.py
@@ -18,7 +18,7 @@ from retrying import retry
 from nesta_daps.common.geo.ratelimit import ratelimit
 
 @cache
-def geocode(**request_kwargs):
+def geocode(**request_kwargs: dict) -> list[dict]:
     """
     Geocoder using the Open Street Map Nominatim API.
 
@@ -45,7 +45,7 @@ def geocode(**request_kwargs):
     return geo_data
 
 
-def retry_if_not_value_error(exception):
+def retry_if_not_value_error(exception: Exception) -> bool:
     """Forces retry to exit if a valueError is returned. Supplied to the
     'retry_on_exception' argument in the retry decorator.
 
@@ -60,7 +60,7 @@ def retry_if_not_value_error(exception):
 
 @retry(stop_max_attempt_number=10, retry_on_exception=retry_if_not_value_error)
 @ratelimit(max_per_second=0.5)
-def _geocode(q=None, **kwargs):
+def _geocode(q: str=None, **kwargs: str) -> dict:
     """Extension of geocode to catch invalid requests to the api and handle errors.
     failure.
 
@@ -95,7 +95,7 @@ def _geocode(q=None, **kwargs):
     return {"lat": lat, "lon": lon}
 
 
-def geocode_dataframe(df):
+def geocode_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """
     A wrapper for the geocode function to process a supplied dataframe using
     the city and country.
@@ -129,13 +129,13 @@ def geocode_dataframe(df):
 
 
 def geocode_batch_list(
-    list,
-    city="city",
-    country="country",
-    latitude="latitude",
-    longitude="longitude",
-    query_method="both",
-):
+    list: list[dict],
+    city: str="city",
+    country: str="country",
+    latitude: str="latitude",
+    longitude: str="longitude",
+    query_method:str ="both",
+) -> list[dict]:
     """Geocodes a dataframe, first by supplying the city and country to the api, if this
     fails a second attempt is made supplying the combination using the q= method.
     The supplied dataframe df is returned with additional columns appended, containing
@@ -175,7 +175,7 @@ def geocode_batch_list(
     return list
 
 
-def generate_composite_key(city=None, country=None):
+def generate_composite_key(city: str=None, country: str=None) -> str:
     """Generates a composite key to use as the primary key for the geographic data.
 
     Args:

--- a/nesta_daps/common/geo/geocode.py
+++ b/nesta_daps/common/geo/geocode.py
@@ -27,9 +27,9 @@ def geocode(**request_kwargs: dict) -> list[dict]:
     https://operations.osmfoundation.org/policies/nominatim/
 
     Args:
-        request_kwargs (dict): Parameters for OSM API.
+        request_kwargs : Parameters for OSM API.
     Returns:
-        JSON from API response.
+        geo_data : JSON from API response.
     """
     # Explictly require json for ease of use
     request_kwargs["format"] = "json"
@@ -50,10 +50,10 @@ def retry_if_not_value_error(exception: Exception) -> bool:
     'retry_on_exception' argument in the retry decorator.
 
     Args:
-        exception (Exception): the raised exception, to check
+        exception : the raised exception, to check
 
     Returns:
-        (bool): False if a ValueError, else True
+        False if a ValueError, else True
     """
     return not isinstance(exception, ValueError)
 
@@ -65,8 +65,8 @@ def _geocode(q: str=None, **kwargs: str) -> dict:
     failure.
 
     Args:
-        q (str): query string, multiple words should be separated with +
-        kwargs (str): name and value of any other valid query parameters
+        q : query string, multiple words should be separated with +
+        kwargs : name and value of any other valid query parameters
 
     Returns:
         dict: lat and lon
@@ -101,9 +101,9 @@ def geocode_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     the city and country.
 
     Args:
-        df (dataframe): a dataframe containing city and country fields.
+        df : a dataframe containing city and country fields.
     Returns:
-        a dataframe with a 'coordinates' column appended.
+        df : a dataframe with a 'coordinates' column appended.
     """
     in_cols = ["city", "country"]
     out_col = "coordinates"
@@ -142,18 +142,18 @@ def geocode_batch_list(
     the latitude and longitude as floats.
 
     Args:
-        df (:obj:`pandas.DataFrame`): input dataframe
-        city (str): name of the input column containing the city
-        country (str): name of the input column containing the country
-        latitude (str): name of the output column containing the latitude
-        longitude (str): name of the output column containing the longitude
-        query_method (int): query methods to attempt:
+        list : input list of dicts
+        city : name of the input column containing the city
+        country : name of the input column containing the country
+        latitude : name of the output column containing the latitude
+        longitude : name of the output column containing the longitude
+        query_method : query methods to attempt:
                                     'city_country_only': city and country only
                                     'query_only': q method only
                                     'both': city, country with fallback to q method
 
     Returns:
-        (:obj:`list`): original list of dicts with lat and lon appended as floats
+        list : original list of dicts with lat and lon appended as floats
     """
     if query_method not in ["city_country_only", "query_only", "both"]:
         raise ValueError(
@@ -179,11 +179,11 @@ def generate_composite_key(city: str=None, country: str=None) -> str:
     """Generates a composite key to use as the primary key for the geographic data.
 
     Args:
-        city (str): name of the city
-        country (str): name of the country
+        city : name of the city
+        country : name of the country
 
     Returns:
-        (str): composite key
+        str : composite key
     """
     try:
         city = city.replace(" ", "-").lower()

--- a/nesta_daps/common/geo/geocode.py
+++ b/nesta_daps/common/geo/geocode.py
@@ -128,8 +128,8 @@ def geocode_dataframe(df):
     return pd.merge(df, _df, how="left", left_on=in_cols, right_on=in_cols)
 
 
-def geocode_batch_dataframe(
-    df,
+def geocode_batch_list(
+    list,
     city="city",
     country="country",
     latitude="latitude",
@@ -153,26 +153,26 @@ def geocode_batch_dataframe(
                                     'both': city, country with fallback to q method
 
     Returns:
-        (:obj:`pandas.DataFrame`): original dataframe with lat and lon appended as floats
+        (:obj:`list`): original list of dicts with lat and lon appended as floats
     """
     if query_method not in ["city_country_only", "query_only", "both"]:
         raise ValueError(
             "Invalid query method, must be 'city_country_only', 'query_only' or 'both'"
         )
 
-    df[latitude], df[longitude] = None, None
 
-    for idx, row in df.iterrows():
+    for item in list:
+        item[latitude], item[longitude] = None, None
         location = None
         if query_method in ["city_country_only", "both"]:
-            location = _geocode(city=row[city], country=row[country])
+            location = _geocode(city=item[city], country=item[country])
         if location is None and query_method in ["query_only", "both"]:
-            query = f"{row[city]} {row[country]}"
+            query = f"{item[city]} {item[country]}"
             location = _geocode(q=query)
         if location is not None:
-            df.loc[idx, latitude] = float(location["lat"])
-            df.loc[idx, longitude] = float(location["lon"])
-    return df
+            item[latitude] = float(location["lat"])
+            item[longitude] = float(location["lon"])
+    return list
 
 
 def generate_composite_key(city=None, country=None):

--- a/nesta_daps/common/geo/iso.py
+++ b/nesta_daps/common/geo/iso.py
@@ -11,12 +11,12 @@ from pycountry_convert import country_alpha2_to_continent_code
 
 
 def alpha2_to_continent_mapping() -> dict:
-    """Wrapper around :obj:`pycountry-convert`'s :obj:`country_alpha2_to_continent_code`
+    """Wrapper around `pycountry-convert`'s `country_alpha2_to_continent_code`
     function to generate a dictionary mapping ISO2 to continent codes, accounting
-    where :obj:`pycountry-convert` has no mapping (e.g. for Vatican).
+    where `pycountry-convert` has no mapping (e.g. for Vatican).
 
     Returns:
-        :obj`dict`
+        continents : dictionary of country codes to continent codes
     """
     continents = {}
     for c in pycountry.countries:
@@ -29,6 +29,15 @@ def alpha2_to_continent_mapping() -> dict:
 
 
 def _country_iso_code(country: str) -> pycountry.countries:
+    """Finds country name from pycountry.country if found
+    using any of name, official_name or common_name.
+
+    Args:
+        country : country to pass to pycountry
+
+    Returns:
+        result : resulting pycountry query
+    """
     for name_type in ["name", "common_name", "official_name"]:
         query = {name_type: country}
         try:
@@ -49,9 +58,9 @@ def country_iso_code(country: str) -> pycountry.countries:
     Wraps the pycountry module to attempt lookup with all name options.
 
     Args:
-        country (str): name of the country to lookup
+        country : name of the country to lookup
     Returns:
-        Country object from the pycountry module
+        result : Country object from the pycountry module
     """
     country = str(country)
     try:
@@ -69,10 +78,10 @@ def country_iso_code_list(list: list[dict], country: str="country") -> list[dict
     using the country name. Also appends the continent code based on the country.
 
     Args:
-        list (:obj:`list`): a list of dicts containing a country field.
-        country (str): field in df containing the country name
+        list : a list of dicts containing a country field.
+        country : field in df containing the country name
     Returns:
-        a list of dicts with country_alpha_2, country_alpha_3, country_numeric, and
+        list : a list of dicts with country_alpha_2, country_alpha_3, country_numeric, and
         continent columns appended.
     """
 
@@ -103,10 +112,10 @@ def country_iso_code_to_name(code: str, iso2: bool=False) -> str:
        pd.apply.
 
     Args:
-        code (str): iso alpha 3 code
-        iso2 (bool): use alpha 2 code instead
+        code : iso alpha 3 code
+        iso2 : use alpha 2 code instead
     Returns:
-        str: name of the country or None if not valid
+        str : name of the country or None if not valid
     """
     try:
         if iso2:

--- a/nesta_daps/common/geo/iso.py
+++ b/nesta_daps/common/geo/iso.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from pycountry_convert import country_alpha2_to_continent_code
 
 
-def alpha2_to_continent_mapping():
+def alpha2_to_continent_mapping() -> dict:
     """Wrapper around :obj:`pycountry-convert`'s :obj:`country_alpha2_to_continent_code`
     function to generate a dictionary mapping ISO2 to continent codes, accounting
     where :obj:`pycountry-convert` has no mapping (e.g. for Vatican).
@@ -28,7 +28,7 @@ def alpha2_to_continent_mapping():
     return continents
 
 
-def _country_iso_code(country):
+def _country_iso_code(country: str) -> pycountry.countries:
     for name_type in ["name", "common_name", "official_name"]:
         query = {name_type: country}
         try:
@@ -41,7 +41,7 @@ def _country_iso_code(country):
 
 
 @lru_cache()
-def country_iso_code(country):
+def country_iso_code(country: str) -> pycountry.countries:
     """
     Look up the ISO 3166 codes for countries.
     https://www.iso.org/glossary-for-iso-3166.html
@@ -63,7 +63,7 @@ def country_iso_code(country):
     return result
 
 
-def country_iso_code_list(list, country="country"):
+def country_iso_code_list(list: list[dict], country: str="country") -> list[dict]:
     """
     A wrapper for the country_iso_code function to apply it to a whole dataframe,
     using the country name. Also appends the continent code based on the country.
@@ -98,7 +98,7 @@ def country_iso_code_list(list, country="country"):
     return list
 
 
-def country_iso_code_to_name(code, iso2=False):
+def country_iso_code_to_name(code: str, iso2: bool=False) -> str:
     """Converts country alpha_3 into name and catches error so this can be used with
        pd.apply.
 

--- a/nesta_daps/common/geo/iso.py
+++ b/nesta_daps/common/geo/iso.py
@@ -63,41 +63,39 @@ def country_iso_code(country):
     return result
 
 
-def country_iso_code_dataframe(df, country="country"):
+def country_iso_code_list(list, country="country"):
     """
     A wrapper for the country_iso_code function to apply it to a whole dataframe,
     using the country name. Also appends the continent code based on the country.
 
     Args:
-        df (:obj:`pandas.DataFrame`): a dataframe containing a country field.
+        list (:obj:`list`): a list of dicts containing a country field.
         country (str): field in df containing the country name
     Returns:
-        a dataframe with country_alpha_2, country_alpha_3, country_numeric, and
+        a list of dicts with country_alpha_2, country_alpha_3, country_numeric, and
         continent columns appended.
     """
-    df["country_alpha_2"], df["country_alpha_3"], df["country_numeric"] = (
-        None,
-        None,
-        None,
-    )
-    df["continent"] = None
 
     continents = alpha2_to_continent_mapping()
     country_codes = None
-    for idx, row in df.iterrows():
+    for item in list:
+        item["country_alpha_2"] = None
+        item["country_alpha_3"] = None
+        item["country_numeric"] = None
+        item["continent"] = None
         try:
-            country_codes = country_iso_code(row[country])
+            country_codes = country_iso_code(item[country])
         except KeyError:
             # some fallback method could go here
             continue
         else:
             if country_codes is None:
                 continue
-        df.at[idx, "country_alpha_2"] = country_codes.alpha_2
-        df.at[idx, "country_alpha_3"] = country_codes.alpha_3
-        df.at[idx, "country_numeric"] = country_codes.numeric
-        df.at[idx, "continent"] = continents.get(country_codes.alpha_2)
-    return df
+        item["country_alpha_2"] = country_codes.alpha_2
+        item["country_alpha_3"] = country_codes.alpha_3
+        item["country_numeric"] = country_codes.numeric
+        item["continent"] = continents.get(country_codes.alpha_2)
+    return list
 
 
 def country_iso_code_to_name(code, iso2=False):

--- a/nesta_daps/common/geo/lookup.py
+++ b/nesta_daps/common/geo/lookup.py
@@ -14,7 +14,7 @@ def get_eu_countries() -> list:
     All EU ISO-2 codes
 
     Returns:
-        data (list): List of ISO-2 codes)
+        data : List of ISO-2 codes)
     """
     url = "https://restcountries.eu/rest/v2/regionalbloc/eu"
     r = requests.get(url)
@@ -27,7 +27,7 @@ def get_continent_lookup() -> list:
     Retrieves continent ISO2 code to continent name mapping from a static open URL.
 
     Returns:
-        data (dict): Key-value pairs of continent-codes and names.
+        data : Key-value pairs of continent-codes and names.
     """
 
     url = (
@@ -48,7 +48,7 @@ def get_country_continent_lookup() -> dict:
     by ISO2 code, from a static open URL.
 
     Returns:
-        data (dict): Values are country_name-continent pairs.
+        data : Values are country_name-continent pairs.
     """
     r = requests.get(COUNTRY_CODES_URL)
     r.raise_for_status()
@@ -76,7 +76,7 @@ def get_country_region_lookup() -> dict:
     from a static open URL.
 
     Returns:
-        data (dict): Values are country_name-region_name pairs.
+        data : Values are country_name-region_name pairs.
     """
     r = requests.get(COUNTRY_CODES_URL)
     r.raise_for_status()
@@ -102,9 +102,9 @@ def get_iso2_to_iso3_lookup(reverse: bool=False) -> dict:
     Retrieves lookup of ISO2 to ISO3 (or reverse).
 
     Args:
-        reverse (bool): If True, return ISO3 to ISO2 lookup instead.
+        reverse : If True, return ISO3 to ISO2 lookup instead.
     Returns:
-        lookup (dict): Key-value pairs of ISO2 to ISO3 codes (or reverse).
+        lookup : Key-value pairs of ISO2 to ISO3 codes (or reverse).
     """
     r = requests.get(COUNTRY_CODES_URL)
     r.raise_for_status()
@@ -130,7 +130,7 @@ def get_disputed_countries() -> dict:
     for making different geo-political decisions
 
     Returns:
-        lookup (dict):
+        dict : dictionary of disputed country lookups
     """
     return {
         "RKS": "SRB",  # Kosovo: Serbia

--- a/nesta_daps/common/geo/lookup.py
+++ b/nesta_daps/common/geo/lookup.py
@@ -9,7 +9,7 @@ COUNTRY_CODES_URL = "https://datahub.io/core/country-codes/r/country-codes.csv"
 
 
 @cache
-def get_eu_countries():
+def get_eu_countries() -> list:
     """
     All EU ISO-2 codes
 
@@ -22,7 +22,7 @@ def get_eu_countries():
 
 
 @cache
-def get_continent_lookup():
+def get_continent_lookup() -> list:
     """
     Retrieves continent ISO2 code to continent name mapping from a static open URL.
 
@@ -42,7 +42,7 @@ def get_continent_lookup():
 
 
 @cache
-def get_country_continent_lookup():
+def get_country_continent_lookup() -> dict:
     """
     Retrieves continent lookups for all world countries,
     by ISO2 code, from a static open URL.
@@ -69,7 +69,7 @@ def get_country_continent_lookup():
 
 
 @cache
-def get_country_region_lookup():
+def get_country_region_lookup() -> dict:
     """
     Retrieves subregions (around 18 in total)
     lookups for all world countries, by ISO2 code,
@@ -97,7 +97,7 @@ def get_country_region_lookup():
 
 
 @cache
-def get_iso2_to_iso3_lookup(reverse=False):
+def get_iso2_to_iso3_lookup(reverse: bool=False) -> dict:
     """
     Retrieves lookup of ISO2 to ISO3 (or reverse).
 
@@ -125,7 +125,7 @@ def get_iso2_to_iso3_lookup(reverse=False):
 
 
 @cache
-def get_disputed_countries():
+def get_disputed_countries() -> dict:
     """Lookup of disputed aliases, to "forgive" disperate datasets
     for making different geo-political decisions
 

--- a/nesta_daps/common/geo/ratelimit.py
+++ b/nesta_daps/common/geo/ratelimit.py
@@ -1,0 +1,26 @@
+'''
+ratelimit
+=========
+Apply rate limiting at a threshold per second
+'''
+
+import time
+
+def ratelimit(max_per_second):
+    '''
+    Args:
+        max_per_second (float): Number of permitted hits per second
+    '''
+    min_interval = 1.0 / float(max_per_second)
+    def decorate(func):
+        last_time_called = [time.perf_counter()]  # `list`s are globally persistified
+        def rate_limited(*args, **kargs):
+            elapsed = time.perf_counter() - last_time_called[0]
+            left_to_wait = min_interval - elapsed
+            if left_to_wait > 0:
+                time.sleep(left_to_wait)
+            ret = func(*args,**kargs)
+            last_time_called[0] = time.perf_counter()
+            return ret
+        return rate_limited  # Note: returning a method
+    return decorate  # Note: returning a method

--- a/nesta_daps/common/geo/ratelimit.py
+++ b/nesta_daps/common/geo/ratelimit.py
@@ -5,8 +5,9 @@ Apply rate limiting at a threshold per second
 '''
 
 import time
+from types import MethodType
 
-def ratelimit(max_per_second):
+def ratelimit(max_per_second: float) -> MethodType:
     '''
     Args:
         max_per_second (float): Number of permitted hits per second

--- a/nesta_daps/common/geo/ratelimit.py
+++ b/nesta_daps/common/geo/ratelimit.py
@@ -8,9 +8,10 @@ import time
 from types import MethodType
 
 def ratelimit(max_per_second: float) -> MethodType:
-    '''
+    '''Limits the rate of execution for a function.
+
     Args:
-        max_per_second (float): Number of permitted hits per second
+        max_per_second : Number of permitted hits per second
     '''
     min_interval = 1.0 / float(max_per_second)
     def decorate(func):

--- a/nesta_daps/common/geo/tests/test_geo.py
+++ b/nesta_daps/common/geo/tests/test_geo.py
@@ -3,23 +3,23 @@ from pandas.testing import assert_frame_equal
 import pytest
 from unittest import mock
 
-from nesta.packages.geo_utils.geocode import geocode
-from nesta.packages.geo_utils.geocode import _geocode
-from nesta.packages.geo_utils.geocode import geocode_dataframe
-from nesta.packages.geo_utils.geocode import geocode_batch_dataframe
-from nesta.packages.geo_utils.geocode import generate_composite_key
-from nesta.packages.geo_utils.country_iso_code import country_iso_code
-from nesta.packages.geo_utils.country_iso_code import country_iso_code_dataframe
-from nesta.packages.geo_utils.country_iso_code import country_iso_code_to_name
-from nesta.packages.geo_utils.lookup import get_continent_lookup
-from nesta.packages.geo_utils.lookup import get_country_region_lookup
-from nesta.packages.geo_utils.lookup import get_country_continent_lookup
+from nesta_daps.common.geo.geocode import geocode
+from nesta_daps.common.geo.geocode import _geocode
+from nesta_daps.common.geo.geocode import geocode_dataframe
+from nesta_daps.common.geo.geocode import geocode_batch_dataframe
+from nesta_daps.common.geo.geocode import generate_composite_key
+from nesta_daps.common.geo.iso import country_iso_code
+from nesta_daps.common.geo.iso import country_iso_code_dataframe
+from nesta_daps.common.geo.iso import country_iso_code_to_name
+from nesta_daps.common.geo.lookup import get_continent_lookup
+from nesta_daps.common.geo.lookup import get_country_region_lookup
+from nesta_daps.common.geo.lookup import get_country_continent_lookup
 
-REQUESTS = "nesta.packages.geo_utils.geocode.requests.get"
-PYCOUNTRY = "nesta.packages.geo_utils.country_iso_code.pycountry.countries.get"
-GEOCODE = "nesta.packages.geo_utils.geocode.geocode"
-_GEOCODE = "nesta.packages.geo_utils.geocode._geocode"
-COUNTRY_ISO_CODE = "nesta.packages.geo_utils.country_iso_code.country_iso_code"
+REQUESTS = "nesta_daps.common.geo.geocode.requests.get"
+PYCOUNTRY = "nesta_daps.common.geo.iso.pycountry.countries.get"
+GEOCODE = "nesta_daps.common.geo.geocode.geocode"
+_GEOCODE = "nesta_daps.common.geo.geocode._geocode"
+COUNTRY_ISO_CODE = "nesta_daps.common.geo.iso.country_iso_code"
 
 
 class TestGeocoding:

--- a/nesta_daps/common/geo/tests/test_ratelimit.py
+++ b/nesta_daps/common/geo/tests/test_ratelimit.py
@@ -1,0 +1,14 @@
+import pytest
+import time
+
+from nesta_daps.common.geo.ratelimit import ratelimit
+
+def test_rate_limit():
+    dummy_func = lambda : None
+    wrapper = ratelimit(1)
+    wrapped = wrapper(dummy_func)
+    previous_time = time.time()
+    for i in range(0, 3):
+        wrapped()
+        assert time.time() - previous_time > 1
+        previous_time = time.time()

--- a/nesta_daps/common/requirements.txt
+++ b/nesta_daps/common/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+ratelimit
+requests
+retrying
+pycountry
+pycountry_convert


### PR DESCRIPTION
Refactors the utils in `geo.common` so that:

- [x] Docs and annotations are modernised as per Python 3.9 guidelines
- [x] There's isn't a pandas in sight (ish)
- [x] Tests are up and running

This PR is by no means extensive, and is essentially a like-for-like copy from old_nesta_daps, with the above minor changes.

There are probably more elegant solutions for the covered functions, but I don't want to change too much before porting the GtR DAG to Metaflow in case any inefficiences are integral to understanding how it should work.